### PR TITLE
Fixed SDK path for the new esp-open-sdk.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN (cd /home/espbuilder/ && git clone https://github.com/tommie/esptool-ck.git 
 
 ENV PATH /home/espbuilder/esp-open-sdk/xtensa-lx106-elf/bin:/home/espbuilder/esp-open-sdk/esptool/:$PATH
 ENV XTENSA_TOOLS_ROOT /home/espbuilder/esp-open-sdk/xtensa-lx106-elf/bin
-ENV SDK_BASE /home/espbuilder/esp-open-sdk/esp_iot_sdk_v1.5.2
+ENV SDK_BASE /home/espbuilder/esp-open-sdk/sdk
 ENV FW_TOOL /home/espbuilder/esptool-ck/esptool
 
 CMD (cd /home/espbuilder/ && /bin/bash)


### PR DESCRIPTION
Corrected the path to the SDK for the latest version of esp-open-sdk. 

This fixes an issue where running "make" to build a project would fail to find the sdk sources probably starting with something like "ets_sys.h no such file or directory"...

This has been tested to successfully build the blinky example.
